### PR TITLE
allow session cancellation at any time while maintaining completion status restrictions

### DIFF
--- a/src/components/listener/SessionStatusUpdate.tsx
+++ b/src/components/listener/SessionStatusUpdate.tsx
@@ -37,12 +37,14 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
     }
   };
 
-  /* ---------- unchanged logic ---------- */
+  /* ---------- Session timing logic ---------- */
   const isSessionInPast = new Date(sessionTime) < new Date();
   const oneHourAfterSession = new Date(sessionTime);
   oneHourAfterSession.setHours(oneHourAfterSession.getHours() + 1);
-  const canUpdateStatus = isSessionInPast && new Date() >= oneHourAfterSession;
+  // Can mark as successful/unsuccessful only after session + 1 hour
+  const canMarkComplete = isSessionInPast && new Date() >= oneHourAfterSession;
 
+  // Show final status for non-pending sessions
   if (currentStatus !== 'pending') {
     return (
       <div className="flex items-center gap-2">
@@ -68,24 +70,6 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
     );
   }
 
-  if (!isSessionInPast) {
-    return (
-      <div className="flex items-center gap-2 text-slate-400">
-        <Clock size={16} />
-        <span className="text-sm">Session hasn’t started yet</span>
-      </div>
-    );
-  }
-
-  if (!canUpdateStatus) {
-    return (
-      <div className="flex items-center gap-2 text-slate-400">
-        <Clock size={16} />
-        <span className="text-sm">Available 1 hr after session start</span>
-      </div>
-    );
-  }
-
   // --- MODAL COMPONENT ---
   const ConfirmModal = () => (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
@@ -96,10 +80,10 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
         </div>
 
         <p className="text-gray-700 mb-6">
-          {targetStatus === 'unsuccessful'
+          {targetStatus === 'cancelled'
+            ? 'Are you sure you want to cancel this session? This action cannot be undone.'
+            : targetStatus === 'unsuccessful'
             ? 'Are you sure you want to mark this session as "Unsuccessful"? This cannot be undone.'
-            : targetStatus === 'cancelled'
-            ? 'Are you sure you want to cancel this session? This will notify the listener and user.'
             : 'Are you sure you want to mark this session as "Successful"?'}
         </p>
 
@@ -127,46 +111,63 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
 
   return (
     <>
-      <div className="flex flex-wrap gap-2">
-        <Button
-          size="sm"
-          onClick={() => {
-            setTargetStatus('successful');
-            setShowConfirmModal(true);
-          }}
-          disabled={isLoading}
-          className="bg-green-600 hover:bg-green-700"
-        >
-          <CheckCircle2 size={14} className="mr-1" />
-          Successful
-        </Button>
+      <div className="flex flex-col gap-3">
+        {/* Cancel button - always available for pending sessions */}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setTargetStatus('cancelled');
+              setShowConfirmModal(true);
+            }}
+            disabled={isLoading}
+            className="border-slate-600 text-slate-700 hover:bg-slate-100"
+          >
+            <AlertCircle size={14} className="mr-1" />
+            Cancel Session
+          </Button>
+        </div>
 
-        <Button
-          size="sm"
-          onClick={() => {
-            setTargetStatus('unsuccessful');
-            setShowConfirmModal(true);
-          }}
-          disabled={isLoading}
-          className="bg-red-600 hover:bg-red-700"
-        >
-          <XCircle size={14} className="mr-1" />
-          Unsuccessful
-        </Button>
+        {/* Completion buttons - only available after session + 1 hour */}
+        {canMarkComplete ? (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              onClick={() => {
+                setTargetStatus('successful');
+                setShowConfirmModal(true);
+              }}
+              disabled={isLoading}
+              className="bg-green-600 hover:bg-green-700"
+            >
+              <CheckCircle2 size={14} className="mr-1" />
+              Successful
+            </Button>
 
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            setTargetStatus('cancelled');
-            setShowConfirmModal(true);
-          }}
-          disabled={isLoading}
-          className="border-slate-600 text-slate-300 hover:bg-slate-800"
-        >
-          <AlertCircle size={14} className="mr-1" />
-          Cancel
-        </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                setTargetStatus('unsuccessful');
+                setShowConfirmModal(true);
+              }}
+              disabled={isLoading}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              <XCircle size={14} className="mr-1" />
+              Unsuccessful
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 text-slate-400">
+            <Clock size={14} />
+            <span className="text-xs">
+              {!isSessionInPast
+                ? "Completion status available after session ends"
+                : "Available 1 hr after session start"}
+            </span>
+          </div>
+        )}
       </div>
 
       {error && <p className="text-xs text-red-400 mt-2">{error}</p>}


### PR DESCRIPTION
- Allow session cancellation at any time for pending sessions
  - Maintain 1-hour restriction for marking sessions as Successful/Unsuccessful
  - Improved UI with separated cancel and completion buttons
  - Better user messaging about when completion status updates become available