### PR TITLE
fix(listener): redirect to login on auth failure instead of showing error

### DIFF
--- a/src/api/listener/choosetopics/api.ts
+++ b/src/api/listener/choosetopics/api.ts
@@ -1,14 +1,19 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { UpdateTopicsRequest, UpdateTopicsResponse } from './types';
 
 export const updateListenerTopics = async (
   listenerId: string,
   topics: string[]
 ): Promise<UpdateTopicsResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.listeners.updateTopics(listenerId), {
@@ -19,6 +24,10 @@ export const updateListenerTopics = async (
     },
     body: JSON.stringify({ topics }),
   });
+
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
 
   if (!response.ok) {
     const error = await response.json();

--- a/src/api/listener/comment/api.ts
+++ b/src/api/listener/comment/api.ts
@@ -1,14 +1,19 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { AddCommentRequest, AddCommentResponse } from './types';
 
 export const addSessionComment = async (
   sessionId: string,
   data: AddCommentRequest
 ): Promise<AddCommentResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.sessions.addComment(sessionId), {
@@ -20,10 +25,14 @@ export const addSessionComment = async (
     body: JSON.stringify(data),
   });
 
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.message || 'Failed to add comment');
   }
 
   return response.json();
-}; 
+};

--- a/src/api/listener/getsessions/api.ts
+++ b/src/api/listener/getsessions/api.ts
@@ -1,8 +1,13 @@
 // Update your API file (e.g., '@/api/listener/getsessions/api.ts')
 import { API_ENDPOINTS } from '@/config/api';
-import type { 
-  GetListenerSessionsResponse, 
-  Session 
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
+import type {
+  GetListenerSessionsResponse,
+  Session
 } from './types';
 
 // Define types for request parameters
@@ -12,9 +17,10 @@ interface GetListenerSessionsRequest {
 }
 
 export const getListenerSessions = async (params: GetListenerSessionsRequest = {}): Promise<GetListenerSessionsResponse> => {
-  const token = localStorage.getItem('listenerToken');
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   // Build query string
@@ -34,9 +40,8 @@ export const getListenerSessions = async (params: GetListenerSessionsRequest = {
       },
     });
 
-    if (response.status === 401) {
-      localStorage.removeItem('listenerToken');
-      throw new Error('Unauthorized access - please log in again');
+    if (handleListenerUnauthorized(response)) {
+      throw new Error('Authentication required');
     }
     if (response.status === 404) {
       throw new Error('Listener not found');

--- a/src/api/listener/listenerprofile/api.ts
+++ b/src/api/listener/listenerprofile/api.ts
@@ -1,11 +1,16 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { ListenerProfileResponse } from './types';
 
 export const getListenerProfile = async (listenerId: string): Promise<ListenerProfileResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.listeners.profile(listenerId), {
@@ -16,6 +21,10 @@ export const getListenerProfile = async (listenerId: string): Promise<ListenerPr
     },
   });
 
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.message || 'Failed to fetch listener profile');
@@ -23,4 +32,4 @@ export const getListenerProfile = async (listenerId: string): Promise<ListenerPr
 
   const result = await response.json();
   return result;
-}; 
+};

--- a/src/api/listener/listenerupdate/api.ts
+++ b/src/api/listener/listenerupdate/api.ts
@@ -1,14 +1,19 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { UpdateListenerRequest, UpdateListenerResponse } from './types';
 
 export const updateListenerProfile = async (
   listenerId: string,
   data: UpdateListenerRequest
 ): Promise<UpdateListenerResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.listeners.updateProfile(listenerId), {
@@ -20,6 +25,10 @@ export const updateListenerProfile = async (
     body: JSON.stringify(data),
   });
 
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.message || 'Failed to update listener profile');
@@ -27,4 +36,4 @@ export const updateListenerProfile = async (
 
   const result = await response.json();
   return result;
-}; 
+};

--- a/src/api/listener/recommendrepeat/api.ts
+++ b/src/api/listener/recommendrepeat/api.ts
@@ -1,13 +1,18 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { RecommendRepeatResponse } from './types';
 
 export const recommendSessionRepeat = async (
   sessionId: string
 ): Promise<RecommendRepeatResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.sessions.recommendRepeat(sessionId), {
@@ -18,10 +23,14 @@ export const recommendSessionRepeat = async (
     },
   });
 
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.message || 'Failed to recommend session repeat');
   }
 
   return response.json();
-}; 
+};

--- a/src/api/listener/repeatsession/api.ts
+++ b/src/api/listener/repeatsession/api.ts
@@ -1,13 +1,18 @@
 import { API_ENDPOINTS } from '@/config/api';
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
 import type { RelatedSessionsResponse, GetRelatedSessionsParams } from './types';
 
 export const getRelatedSessions = async ({
   sessionId,
 }: GetRelatedSessionsParams): Promise<RelatedSessionsResponse> => {
-  const token = localStorage.getItem('listenerToken');
-
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   try {
@@ -22,8 +27,8 @@ export const getRelatedSessions = async ({
       }
     );
 
-    if (response.status === 401) {
-      throw new Error('Unauthorized access');
+    if (handleListenerUnauthorized(response)) {
+      throw new Error('Authentication required');
     }
 
     if (response.status === 404) {

--- a/src/api/listener/topicsmanage/api.ts
+++ b/src/api/listener/topicsmanage/api.ts
@@ -1,15 +1,20 @@
 import { API_ENDPOINTS } from '@/config/api';
-import type { 
-  GetListenerTopicsResponse, 
-  DeleteTopicsRequest, 
-  DeleteTopicsResponse 
+import {
+  getListenerToken,
+  handleListenerUnauthorized,
+  redirectToListenerLogin,
+} from '@/utils/listenerAuth';
+import type {
+  GetListenerTopicsResponse,
+  DeleteTopicsRequest,
+  DeleteTopicsResponse
 } from './types';
 
 export const getListenerTopics = async (listenerId: string): Promise<GetListenerTopicsResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.listeners.getListenerTopics(listenerId), {
@@ -19,6 +24,10 @@ export const getListenerTopics = async (listenerId: string): Promise<GetListener
       'Content-Type': 'application/json',
     },
   });
+
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
 
   if (!response.ok) {
     const error = await response.json();
@@ -32,10 +41,10 @@ export const deleteListenerTopics = async (
   listenerId: string,
   topics: string[]
 ): Promise<DeleteTopicsResponse> => {
-  const token = localStorage.getItem('listenerToken');
-  
+  const token = getListenerToken();
   if (!token) {
-    throw new Error('No authentication token found');
+    redirectToListenerLogin('invalid');
+    throw new Error('Authentication required');
   }
 
   const response = await fetch(API_ENDPOINTS.listeners.deleteListenerTopics(listenerId), {
@@ -47,10 +56,14 @@ export const deleteListenerTopics = async (
     body: JSON.stringify({ topics }),
   });
 
+  if (handleListenerUnauthorized(response)) {
+    throw new Error('Authentication required');
+  }
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.message || 'Failed to delete listener topics');
   }
 
   return response.json();
-}; 
+};

--- a/src/components/listener/ListenerLayout.tsx
+++ b/src/components/listener/ListenerLayout.tsx
@@ -1,33 +1,32 @@
 import React, { useEffect, useState } from 'react';
 import { ListenerSidebar } from './ListenerSidebar';
 import { Bell, Menu } from 'lucide-react';
+import { requireListenerAuth } from '@/utils/listenerAuth';
 
 interface ListenerLayoutProps {
   children: React.ReactNode;
 }
 
-interface ListenerData {
-  _id: string;
-  name: string;
-  email: string;
-}
-
 export const ListenerLayout: React.FC<ListenerLayoutProps> = ({ children }) => {
   const [listenerName, setListenerName] = useState<string>('');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isAuthChecked, setIsAuthChecked] = useState(false);
 
   useEffect(() => {
-    // Get listener data from localStorage
-    const listenerDataStr = localStorage.getItem('listenerData');
-    if (listenerDataStr) {
-      try {
-        const listenerData: ListenerData = JSON.parse(listenerDataStr);
-        setListenerName(listenerData.name || '');
-      } catch (error) {
-        console.error('Error parsing listener data:', error);
-      }
-    }
+    // Validate session before rendering any listener page. If the session is
+    // missing or corrupted, requireListenerAuth() triggers a redirect to the
+    // login screen and returns null — in that case we keep the layout blank
+    // so no half-rendered page flashes during navigation.
+    const auth = requireListenerAuth();
+    if (!auth) return;
+    setListenerName(auth.listenerData.name || '');
+    setIsAuthChecked(true);
   }, []);
+
+  if (!isAuthChecked) {
+    // Render nothing while the auth check (and any redirect) is in flight.
+    return null;
+  }
 
   return (
     <div className="flex h-screen bg-gray-50">

--- a/src/components/listener/ListenerProfile.tsx
+++ b/src/components/listener/ListenerProfile.tsx
@@ -9,6 +9,7 @@ import type { ListenerProfile as ListenerProfileType } from '@/api/listener/list
 import type { UpdateListenerRequest } from '@/api/listener/listenerupdate/types';
 import { UserCircle, Phone, Mail, Clock, Pencil, Save, X, User } from 'lucide-react';
 import { useRouter } from 'next/router';
+import { requireListenerAuth } from '@/utils/listenerAuth';
 
 interface ProfileFormData {
   name: string;
@@ -42,13 +43,10 @@ export const ListenerProfile = () => {
 
   useEffect(() => {
     const fetchProfile = async () => {
+      const auth = requireListenerAuth();
+      if (!auth) return; // redirect already triggered
       try {
-        const listenerData = localStorage.getItem('listenerData');
-        if (!listenerData) {
-          throw new Error('No listener data found');
-        }
-        const { _id } = JSON.parse(listenerData);
-        const response = await getListenerProfile(_id);
+        const response = await getListenerProfile(auth.listenerData._id);
         setProfile(response.listener);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load profile');
@@ -119,9 +117,9 @@ export const ListenerProfile = () => {
     setError(null);
 
     try {
-      const listenerData = localStorage.getItem('listenerData');
-      if (!listenerData) throw new Error('No listener data found');
-      const parsedListenerData = JSON.parse(listenerData);
+      const auth = requireListenerAuth();
+      if (!auth) return; // redirect already triggered
+      const parsedListenerData = auth.listenerData;
       const { _id } = parsedListenerData;
 
       const updateData: UpdateListenerRequest = {

--- a/src/components/listener/ListenerScheduleEditor.tsx
+++ b/src/components/listener/ListenerScheduleEditor.tsx
@@ -8,6 +8,7 @@ import { updateListenerProfile } from '@/api/listener/listenerupdate/api';
 import type { ListenerProfile, DayAvailability } from '@/api/listener/listenerprofile/types';
 import type { UpdateListenerRequest } from '@/api/listener/listenerupdate/types';
 import { Clock, Save, X, Check, X as XIcon, Plus } from 'lucide-react';
+import { requireListenerAuth } from '@/utils/listenerAuth';
 
 // Time slots for selection
 const HOURS = Array.from({ length: 12 }, (_, i) => i + 1);
@@ -48,13 +49,10 @@ export const ListenerScheduleEditor = () => {
 
   useEffect(() => {
     const fetchProfile = async () => {
+      const auth = requireListenerAuth();
+      if (!auth) return; // redirect already triggered
       try {
-        const listenerData = localStorage.getItem('listenerData');
-        if (!listenerData) {
-          throw new Error('No listener data found');
-        }
-        const { _id } = JSON.parse(listenerData);
-        const response = await getListenerProfile(_id);
+        const response = await getListenerProfile(auth.listenerData._id);
         setProfile(response.listener);
         setAvailability(response.listener.availability);
       } catch (err) {
@@ -178,11 +176,9 @@ export const ListenerScheduleEditor = () => {
         }))
       };
 
-      const listenerData = localStorage.getItem('listenerData');
-      if (!listenerData) throw new Error('No listener data found');
-      
-      const { _id } = JSON.parse(listenerData);
-      await updateListenerProfile(_id, updateData);
+      const auth = requireListenerAuth();
+      if (!auth) return; // redirect already triggered
+      await updateListenerProfile(auth.listenerData._id, updateData);
       setError('Schedule updated successfully!');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update schedule');

--- a/src/pages/listener/login/index.tsx
+++ b/src/pages/listener/login/index.tsx
@@ -5,6 +5,17 @@ import { Card } from '@/components/ui/card';
 export default function ListenerLoginPage() {
   const router = useRouter();
 
+  // The session helpers redirect here with ?reason=expired (a 401 was hit on
+  // an authenticated request) or ?reason=invalid (the local session was missing
+  // or corrupted). A bare visit has no reason and shows no banner.
+  const reason = typeof router.query.reason === 'string' ? router.query.reason : null;
+  const banner =
+    reason === 'expired'
+      ? 'Your session has expired. Please sign in again.'
+      : reason === 'invalid'
+        ? 'Your session is invalid. Please sign in again.'
+        : null;
+
   const handleLoginSuccess = () => {
     router.push('/listener/dashboard');
   };
@@ -13,9 +24,14 @@ export default function ListenerLoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full">
         <Card className="p-8">
+          {banner && (
+            <div className="mb-4 p-3 rounded-md border border-amber-300 bg-amber-50 text-amber-800 text-sm">
+              {banner}
+            </div>
+          )}
           <ListenerLogin onSuccess={handleLoginSuccess} />
         </Card>
       </div>
     </div>
   );
-} 
+}

--- a/src/utils/listenerAuth.ts
+++ b/src/utils/listenerAuth.ts
@@ -1,0 +1,113 @@
+/**
+ * Centralized authentication helpers for the listener flow.
+ *
+ * The listener side of the dashboard stores two things in localStorage:
+ *   - listenerToken: the JWT used as Bearer auth on API requests
+ *   - listenerData:  JSON-encoded { _id, name, email, ... } used by the UI
+ *
+ * If either is missing, malformed, or rejected by the backend (401), the
+ * user must be sent back to /listener/login. These helpers exist so every
+ * page and API call handles that case the same way.
+ */
+
+export interface ListenerData {
+  _id: string;
+  name: string;
+  email: string;
+  [key: string]: any;
+}
+
+export type AuthFailureReason = 'expired' | 'invalid';
+
+const TOKEN_KEY = 'listenerToken';
+const DATA_KEY = 'listenerData';
+
+export const getListenerToken = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(TOKEN_KEY);
+};
+
+export const getListenerData = (): ListenerData | null => {
+  if (typeof window === 'undefined') return null;
+  const raw = localStorage.getItem(DATA_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && typeof parsed._id === 'string') {
+      return parsed as ListenerData;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const clearListenerSession = (): void => {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(DATA_KEY);
+};
+
+/**
+ * Send the user to the listener login screen and clear any partial session.
+ * The optional reason becomes a query param the login page reads to show
+ * a contextual banner ("Your session has expired" / "Your session is invalid").
+ * No reason = silent redirect, used for fresh visitors who were never logged in.
+ */
+export const redirectToListenerLogin = (reason?: AuthFailureReason): void => {
+  if (typeof window === 'undefined') return;
+  clearListenerSession();
+  const path = reason ? `/listener/login?reason=${reason}` : '/listener/login';
+  window.location.href = path;
+};
+
+/**
+ * Validate that the listener has a usable session. Call this from page-level
+ * components (typically inside a useEffect) before doing any data fetching.
+ *
+ * Returns { token, listenerData } if valid. Returns null after triggering a
+ * redirect if the session is missing or corrupted; callers should bail out
+ * immediately on null:
+ *
+ *   const auth = requireListenerAuth();
+ *   if (!auth) return;
+ *   // safe to use auth.token / auth.listenerData here
+ */
+export const requireListenerAuth = ():
+  | { token: string; listenerData: ListenerData }
+  | null => {
+  const token = getListenerToken();
+  const listenerData = getListenerData();
+
+  if (!token && !listenerData) {
+    // Fresh visitor or fully cleared session — no banner needed
+    redirectToListenerLogin();
+    return null;
+  }
+
+  if (!token || !listenerData) {
+    // Half-state: token without data, or data without token / unparseable
+    redirectToListenerLogin('invalid');
+    return null;
+  }
+
+  return { token, listenerData };
+};
+
+/**
+ * Inspect a fetch Response and trigger a login redirect if it's a 401.
+ * Returns true when a redirect was started (caller should abort further work),
+ * false when the response is fine to continue processing.
+ *
+ *   const response = await fetch(...);
+ *   if (handleListenerUnauthorized(response)) {
+ *     throw new Error('Authentication required');
+ *   }
+ */
+export const handleListenerUnauthorized = (response: Response): boolean => {
+  if (response.status === 401) {
+    redirectToListenerLogin('expired');
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
## Summary
Listeners hitting any authentication issue (missing token, corrupted localStorage, expired/invalid token rejected by the backend) previously saw a raw error string rendered into the page (e.g. "No authentication token found"). They had to know to navigate back to `/listener/login` themselves. This PR centralises listener auth handling and bounces every failure straight to the login screen with a contextual banner.

## What changes for the user
- **Direct navigation to any `/listener/*` page while logged out** → instant redirect to `/listener/login`, blank screen in between (no flash of half-loaded content)
- **API call returns 401 (token expired or revoked)** → token cleared, redirect to `/listener/login?reason=expired`, banner reads *"Your session has expired. Please sign in again."*
- **Corrupted localStorage state (token without data, unparseable JSON, etc.)** → redirect to `/listener/login?reason=invalid`, banner reads *"Your session is invalid. Please sign in again."*
- **Bare visit to `/listener/login`** → no banner, clean login screen

## Implementation
- **New** `src/utils/listenerAuth.ts` — single source of truth for listener auth state. Exposes `getListenerToken`, `getListenerData`, `clearListenerSession`, `redirectToListenerLogin`, `requireListenerAuth`, `handleListenerUnauthorized`. Modeled on the existing admin `validateToken` / `handleUnauthorized` pattern but for the listener flow (different localStorage keys, different login route).
- **Layout-level guard** in `ListenerLayout.tsx` — calls `requireListenerAuth()` on mount via `useEffect`, renders `null` until the check passes. This catches direct URL navigation by unauthenticated users for every listener page (`/listener/dashboard`, `/listener/profile`, `/listener/schedule`, `/listener/sessions`, etc.) without each page having to opt in.
- **All 8 listener API helpers** updated to call `handleListenerUnauthorized(response)` after every fetch and redirect on 401 instead of throwing an error string. Also replaced ad-hoc `localStorage.getItem('listenerToken')` with the centralised `getListenerToken()`.
- **Two component files** (`ListenerProfile.tsx`, `ListenerScheduleEditor.tsx`) replaced inline `localStorage.getItem('listenerData')` + manual JSON parse with `requireListenerAuth()` helper calls.
- **Login page** (`pages/listener/login/index.tsx`) reads `router.query.reason` and renders a contextual amber banner above the form for `expired` and `invalid`. The banner stays until login (does not auto-dismiss).

## Files changed
| Type | File |
|---|---|
| New | [src/utils/listenerAuth.ts](src/utils/listenerAuth.ts) |
| Layout | [src/components/listener/ListenerLayout.tsx](src/components/listener/ListenerLayout.tsx) |
| Components | [src/components/listener/ListenerProfile.tsx](src/components/listener/ListenerProfile.tsx), [src/components/listener/ListenerScheduleEditor.tsx](src/components/listener/ListenerScheduleEditor.tsx) |
| Login page | [src/pages/listener/login/index.tsx](src/pages/listener/login/index.tsx) |
| API helpers | [listenerprofile](src/api/listener/listenerprofile/api.ts), [listenerupdate](src/api/listener/listenerupdate/api.ts), [choosetopics](src/api/listener/choosetopics/api.ts), [comment](src/api/listener/comment/api.ts), [getsessions](src/api/listener/getsessions/api.ts), [recommendrepeat](src/api/listener/recommendrepeat/api.ts), [repeatsession](src/api/listener/repeatsession/api.ts), [topicsmanage](src/api/listener/topicsmanage/api.ts) |

## What this does NOT touch
- Admin auth flow (`utils/api.ts`, `utils/auth.ts`) — different code path, working as designed
- Backend token validation — already correct
- The successful-auth happy path

## Test plan
- [ ] **Fresh visitor**: clear localStorage, navigate to `/listener/profile` → instantly redirected to `/listener/login`, no banner
- [ ] **Expired session**: log in, then in DevTools modify `listenerToken` to a garbage value, then click anything that triggers an API call → redirected to `/listener/login?reason=expired`, "expired" banner shown
- [ ] **Corrupted data**: log in, then in DevTools delete `listenerData` (keep token), navigate to `/listener/profile` → redirected to `/listener/login?reason=invalid`, "invalid" banner shown
- [ ] **Half state**: log in, then delete `listenerToken` (keep `listenerData`), navigate to any listener page → redirected to `/listener/login?reason=invalid`
- [ ] **Bare visit**: navigate to `/listener/login` directly → no banner, clean form
- [ ] **Successful login**: from any of the above redirects, log in successfully → lands on `/listener/dashboard`, banner gone, no leftover error state
- [ ] **No regressions**: log in cleanly, edit profile, save → still works (PR readysocial/MY-DASHBOARDS#36 functionality)
- [ ] **No regressions**: log in cleanly, edit schedule, save → still works
- [ ] Verify `npx tsc --noEmit` passes (already verified locally)
