### PR TITLE
Add reusable confirmation dialog for all impactful actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@heroicons/react": "^2.1.5",
     "@next/swc-linux-x64-gnu": "^15.1.4",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-select": "^2.1.2",

--- a/src/components/AppVersionControl.tsx
+++ b/src/components/AppVersionControl.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api';
 import { API_URL } from '@/config/api';
+import { confirm } from '@/lib/confirm';
 
 const AppVersionControl: React.FC = () => {
   useEffect(() => {
@@ -70,9 +71,11 @@ const AppVersionControl: React.FC = () => {
       return;
     }
 
-    const confirmed = window.confirm(
-      `Are you sure you want to set the minimum ${platformLabel} version to ${version}? Users on older versions will be forced to update.`
-    );
+    const confirmed = await confirm({
+      title: `Update ${platformLabel} Minimum Version`,
+      description: `Are you sure you want to set the minimum ${platformLabel} version to ${version}? Users on older versions will be forced to update.`,
+      confirmText: 'Update Version',
+    });
     if (!confirmed) return;
 
     setLoading(true);

--- a/src/components/Listeners.tsx
+++ b/src/components/Listeners.tsx
@@ -6,15 +6,16 @@ import { Listener, FormErrors, Message, TimeSlot } from '../types/listener';
 import { DAYS_OF_WEEK, DEFAULT_TIME_SLOTS, GENDERS } from '../constants/listener';
 import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api';
 import { API_URL } from '@/config/api';
-import { 
-  activateDeactivateListener, 
-  getListener, 
-  updateListener, 
-  createListener, 
+import {
+  activateDeactivateListener,
+  getListener,
+  updateListener,
+  createListener,
   deleteListener,
   inviteListener,
   updateListenerAvailability
 } from '../api/listener/api';
+import { confirm } from '@/lib/confirm';
 
 const Listeners: React.FC = (): JSX.Element => {
 
@@ -172,7 +173,15 @@ const Listeners: React.FC = (): JSX.Element => {
   // Send Message to Listener
   const sendMessageToListener = async () => {
     if (!validateToken() || !selectedListener) return;
-  
+
+    const confirmed = await confirm({
+      title: 'Send Message',
+      description: `Send this message to ${selectedListener.name}?`,
+      confirmText: 'Send',
+      variant: 'default',
+    });
+    if (!confirmed) return;
+
     try {
       const response = await fetch(`${API_URL}/listeners/${selectedListener._id}/messages`, {
         method: 'POST',
@@ -284,7 +293,15 @@ const Listeners: React.FC = (): JSX.Element => {
     if (!validateForm() || !selectedListener?._id) {
       return;
     }
-  
+
+    const confirmed = await confirm({
+      title: 'Update Availability',
+      description: `Save availability changes for ${selectedListener.name}?`,
+      confirmText: 'Save',
+      variant: 'default',
+    });
+    if (!confirmed) return;
+
     setIsSubmitting(true);
     try {
       await updateListenerAvailability(selectedListener._id, newListener.availability);
@@ -490,15 +507,15 @@ const addTimeSlot = (dayOfWeek: string) => {
 
     // Show confirmation dialog for both activation and deactivation
     const action = currentStatus ? 'deactivate' : 'activate';
-    const confirmed = window.confirm(
-      currentStatus 
+    const confirmed = await confirm({
+      title: `${currentStatus ? 'Deactivate' : 'Activate'} Listener`,
+      description: currentStatus
         ? 'Are you sure you want to deactivate this listener? This will prevent them from receiving new sessions.'
-        : 'Are you sure you want to activate this listener? This will allow them to receive new sessions.'
-    );
-    
-    if (!confirmed) {
-      return;
-    }
+        : 'Are you sure you want to activate this listener? This will allow them to receive new sessions.',
+      confirmText: currentStatus ? 'Deactivate' : 'Activate',
+    });
+
+    if (!confirmed) return;
 
     try {
       setIsActivating(true);
@@ -517,9 +534,12 @@ const addTimeSlot = (dayOfWeek: string) => {
   const handleDeleteListener = async (listenerId: string) => {
     if (!validateToken()) return;
 
-    if (!window.confirm('Are you sure you want to delete this listener?')) {
-      return;
-    }
+    const confirmed = await confirm({
+      title: 'Delete Listener',
+      description: 'Are you sure you want to delete this listener? This action cannot be undone.',
+      confirmText: 'Delete',
+    });
+    if (!confirmed) return;
 
     try {
       await deleteListener(listenerId);

--- a/src/components/Sessions.tsx
+++ b/src/components/Sessions.tsx
@@ -22,7 +22,8 @@ import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api'
 import { API_URL } from '@/config/api';
 import { SessionMeetingLink } from '@/components/listener/SessionMeetingLink';
 import { Button } from '@/components/ui/button';
-import { SessionStatusUpdate } from '@/components/listener/SessionStatusUpdate'; 
+import { SessionStatusUpdate } from '@/components/listener/SessionStatusUpdate';
+import { confirm } from '@/lib/confirm';
 
 interface User {
   _id: string;
@@ -512,9 +513,12 @@ const Sessions: React.FC = () => {
   };
 
   const handleDeleteTopic = async (topicId: string) => {
-    if (!window.confirm('Are you sure you want to delete this topic? This action cannot be undone.')) {
-      return;
-    }
+    const confirmed = await confirm({
+      title: 'Delete Topic',
+      description: 'Are you sure you want to delete this topic? This action cannot be undone.',
+      confirmText: 'Delete',
+    });
+    if (!confirmed) return;
     setIsTopicOperationLoading(true);
     try {
       const response = await fetch(`${API_URL}/sessions/topics/${topicId}`, {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api';
 import { API_URL } from '@/config/api';
+import { confirm } from '@/lib/confirm';
 
 const Settings: React.FC = () => {
   useEffect(() => {
@@ -42,9 +43,9 @@ const Settings: React.FC = () => {
   };
 
   const handlePasswordChange = async (e: React.FormEvent) => {
-    if (!validateToken()) return;
     e.preventDefault();
-    
+    if (!validateToken()) return;
+
     if (passwordFormData.newPassword !== passwordFormData.confirmPassword) {
       showAlert('error', 'New passwords do not match');
       return;
@@ -59,6 +60,13 @@ const Settings: React.FC = () => {
       showAlert('error', 'Please enter your current password');
       return;
     }
+
+    const confirmed = await confirm({
+      title: 'Change Password',
+      description: 'Are you sure you want to change your admin password?',
+      confirmText: 'Change Password',
+    });
+    if (!confirmed) return;
 
     setLoading(true);
 

--- a/src/components/Users.tsx
+++ b/src/components/Users.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Search, Plus, Eye, MessageCircle } from 'lucide-react';
 import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api';
 import { API_URL } from '@/config/api';
+import { confirm } from '@/lib/confirm';
 
 // --- ADJUSTED INTERFACE: Removed firstName, lastName as they are not part of the User object used for display ---
 interface User {
@@ -450,6 +451,15 @@ const Users: React.FC = () => {
         console.log("[Users] Token validation failed for sending notification.");
         return;
     }
+
+    const confirmed = await confirm({
+      title: 'Send Notification',
+      description: 'Are you sure you want to send this notification to the user?',
+      confirmText: 'Send',
+      variant: 'default',
+    });
+    if (!confirmed) return;
+
     try {
       const notificationData: NotificationRequest = {
         userId,

--- a/src/components/listener/ListenerScheduleEditor.tsx
+++ b/src/components/listener/ListenerScheduleEditor.tsx
@@ -9,6 +9,7 @@ import type { ListenerProfile, DayAvailability } from '@/api/listener/listenerpr
 import type { UpdateListenerRequest } from '@/api/listener/listenerupdate/types';
 import { Clock, Save, X, Check, X as XIcon, Plus } from 'lucide-react';
 import { requireListenerAuth } from '@/utils/listenerAuth';
+import { confirm } from '@/lib/confirm';
 
 // Time slots for selection
 const HOURS = Array.from({ length: 12 }, (_, i) => i + 1);
@@ -155,6 +156,14 @@ export const ListenerScheduleEditor = () => {
 
   const handleSave = async () => {
     if (!profile) return;
+
+    const confirmed = await confirm({
+      title: 'Save Schedule',
+      description: 'Are you sure you want to save these schedule changes?',
+      confirmText: 'Save Changes',
+      variant: 'default',
+    });
+    if (!confirmed) return;
 
     setSaving(true);
     setError(null);

--- a/src/components/listener/ListenerTopicsManager.tsx
+++ b/src/components/listener/ListenerTopicsManager.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Tag, Check, X, Trash2 } from 'lucide-react';
 import { getListenerTopics, deleteListenerTopics } from '@/api/listener/topicsmanage/api';
 import type { GetListenerTopicsResponse } from '@/api/listener/topicsmanage/types';
+import { confirm } from '@/lib/confirm';
 
 interface ListenerTopicsManagerProps {
   listenerId: string;
@@ -35,6 +36,13 @@ export const ListenerTopicsManager = ({ listenerId, onUpdateSuccess }: ListenerT
   }, [listenerId]);
 
   const handleDeleteTopic = async (topicId: string) => {
+    const confirmed = await confirm({
+      title: 'Remove Topic',
+      description: 'Are you sure you want to remove this topic from the listener?',
+      confirmText: 'Remove',
+    });
+    if (!confirmed) return;
+
     setIsDeleting(true);
     setError(null);
     setSuccessMessage(null);

--- a/src/components/listener/SessionStatusUpdate.tsx
+++ b/src/components/listener/SessionStatusUpdate.tsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { updateSessionStatus } from '@/api/admin/sessions/api';
 import type { SessionStatus } from '@/api/listener/updatestatus/types'; // ✅ correct file
-import { AlertCircle, CheckCircle2, XCircle, Clock, AlertTriangle } from 'lucide-react';
+import { AlertCircle, CheckCircle2, XCircle, Clock } from 'lucide-react';
+import { confirm } from '@/lib/confirm';
 
 interface SessionStatusUpdateProps {
   sessionId: string;
@@ -20,16 +21,26 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const [targetStatus, setTargetStatus] = useState<SessionStatus | null>(null);
 
   const handleStatusUpdate = async (newStatus: SessionStatus) => {
+    const messages: Record<string, string> = {
+      cancelled: 'Are you sure you want to cancel this session? This action cannot be undone.',
+      unsuccessful: 'Are you sure you want to mark this session as "Unsuccessful"? This cannot be undone.',
+      successful: 'Are you sure you want to mark this session as "Successful"?',
+    };
+
+    const confirmed = await confirm({
+      title: 'Confirm Status Change',
+      description: messages[newStatus] || `Change session status to "${newStatus}"?`,
+      confirmText: 'Confirm',
+    });
+    if (!confirmed) return;
+
     try {
       setIsLoading(true);
       setError(null);
       const result = await updateSessionStatus(sessionId, { status: newStatus });
       onStatusUpdated(result.session.status);
-      setShowConfirmModal(false); // Close modal after success
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update status');
     } finally {
@@ -70,45 +81,6 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
     );
   }
 
-  // --- MODAL COMPONENT ---
-  const ConfirmModal = () => (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
-        <div className="flex items-center gap-3 mb-4">
-          <AlertTriangle className="h-8 w-8 text-yellow-600" />
-          <h3 className="text-lg font-semibold text-gray-900">Confirm Status Change</h3>
-        </div>
-
-        <p className="text-gray-700 mb-6">
-          {targetStatus === 'cancelled'
-            ? 'Are you sure you want to cancel this session? This action cannot be undone.'
-            : targetStatus === 'unsuccessful'
-            ? 'Are you sure you want to mark this session as "Unsuccessful"? This cannot be undone.'
-            : 'Are you sure you want to mark this session as "Successful"?'}
-        </p>
-
-        <div className="flex justify-end gap-3">
-          <Button
-            variant="outline"
-            onClick={() => setShowConfirmModal(false)}
-            className="text-gray-700 hover:bg-gray-50"
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={() => {
-              if (targetStatus) handleStatusUpdate(targetStatus);
-            }}
-            disabled={isLoading}
-          >
-            {isLoading ? 'Processing...' : 'Confirm'}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-
   return (
     <>
       <div className="flex flex-col gap-3">
@@ -117,10 +89,7 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
           <Button
             size="sm"
             variant="outline"
-            onClick={() => {
-              setTargetStatus('cancelled');
-              setShowConfirmModal(true);
-            }}
+            onClick={() => handleStatusUpdate('cancelled')}
             disabled={isLoading}
             className="border-slate-600 text-slate-700 hover:bg-slate-100"
           >
@@ -134,10 +103,7 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
           <div className="flex flex-wrap gap-2">
             <Button
               size="sm"
-              onClick={() => {
-                setTargetStatus('successful');
-                setShowConfirmModal(true);
-              }}
+              onClick={() => handleStatusUpdate('successful')}
               disabled={isLoading}
               className="bg-green-600 hover:bg-green-700"
             >
@@ -147,10 +113,7 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
 
             <Button
               size="sm"
-              onClick={() => {
-                setTargetStatus('unsuccessful');
-                setShowConfirmModal(true);
-              }}
+              onClick={() => handleStatusUpdate('unsuccessful')}
               disabled={isLoading}
               className="bg-red-600 hover:bg-red-700"
             >
@@ -171,9 +134,6 @@ export const SessionStatusUpdate: React.FC<SessionStatusUpdateProps> = ({
       </div>
 
       {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
-
-      {/* Render modal only when needed */}
-      {showConfirmModal && <ConfirmModal />}
     </>
   );
 };

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[2000] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[2000] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -17,10 +17,10 @@ export function ConfirmDialog() {
 
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => { if (!isOpen) respond(false); }}>
-      <AlertDialogContent>
+      <AlertDialogContent className="bg-white border border-gray-200 shadow-xl">
         <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
+          <AlertDialogTitle className="text-gray-900">{title}</AlertDialogTitle>
+          <AlertDialogDescription className="text-gray-600">{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={() => respond(false)}>

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useConfirmState, respond } from '@/lib/confirm';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function ConfirmDialog() {
+  const { open, title, description, confirmText, variant } = useConfirmState();
+
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => { if (!isOpen) respond(false); }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => respond(false)}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => respond(true)}
+            className={cn(
+              variant === 'destructive'
+                ? buttonVariants({ variant: 'destructive' })
+                : buttonVariants({ variant: 'default' })
+            )}
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/lib/confirm.ts
+++ b/src/lib/confirm.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react';
+
+interface ConfirmState {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmText: string;
+  variant: 'default' | 'destructive';
+  resolve: ((value: boolean) => void) | null;
+}
+
+const defaultState: ConfirmState = {
+  open: false,
+  title: '',
+  description: '',
+  confirmText: 'Confirm',
+  variant: 'destructive',
+  resolve: null,
+};
+
+let memoryState: ConfirmState = { ...defaultState };
+
+const listeners: Array<(state: ConfirmState) => void> = [];
+
+function dispatch(state: ConfirmState) {
+  memoryState = state;
+  listeners.forEach((listener) => listener(memoryState));
+}
+
+interface ConfirmOptions {
+  title: string;
+  description: string;
+  confirmText?: string;
+  variant?: 'default' | 'destructive';
+}
+
+function confirm({
+  title,
+  description,
+  confirmText = 'Confirm',
+  variant = 'destructive',
+}: ConfirmOptions): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    dispatch({
+      open: true,
+      title,
+      description,
+      confirmText,
+      variant,
+      resolve,
+    });
+  });
+}
+
+function respond(value: boolean) {
+  if (memoryState.resolve) {
+    memoryState.resolve(value);
+  }
+  dispatch({ ...defaultState });
+}
+
+function useConfirmState() {
+  const [state, setState] = useState<ConfirmState>(memoryState);
+
+  useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return state;
+}
+
+export { confirm, respond, useConfirmState };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -15,5 +16,10 @@ export default function App({ Component, pageProps }: AppProps) {
     return null;
   }
 
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Component {...pageProps} />
+      <ConfirmDialog />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Introduce a centralized `confirm()` function (in `src/lib/confirm.ts`) that mirrors the existing `toast()` pattern — module-scoped state with a listener-based renderer
- Add `<ConfirmDialog />` component (Radix AlertDialog) mounted once in `_app.tsx`
- Replace all `window.confirm()` calls and the inline ConfirmModal in SessionStatusUpdate
- Add confirmation to 7 actions that previously had none

## How to use
```ts
import { confirm } from '@/lib/confirm';

const ok = await confirm({
  title: 'Delete Item',
  description: 'Are you sure? This cannot be undone.',
  confirmText: 'Delete',       // optional, defaults to "Confirm"
  variant: 'destructive',      // optional, defaults to "destructive"
});
if (!ok) return;
```

## Files changed

| File | Change |
|------|--------|
| `src/lib/confirm.ts` | NEW — confirm store (mirrors `use-toast.ts`) |
| `src/components/ui/alert-dialog.tsx` | NEW — shadcn AlertDialog primitive |
| `src/components/ui/confirm-dialog.tsx` | NEW — renderer component |
| `src/pages/_app.tsx` | Mount `<ConfirmDialog />` |
| `src/components/AppVersionControl.tsx` | Replace `window.confirm` |
| `src/components/Sessions.tsx` | Replace `window.confirm` |
| `src/components/Listeners.tsx` | Replace 2x `window.confirm` + add 3 new |
| `src/components/listener/SessionStatusUpdate.tsx` | Remove 40-line inline modal |
| `src/components/Settings.tsx` | Add confirmation to password change |
| `src/components/Users.tsx` | Add confirmation to send notification |
| `src/components/listener/ListenerScheduleEditor.tsx` | Add confirmation to save schedule |
| `src/components/listener/ListenerTopicsManager.tsx` | Add confirmation to topic removal |

## Test plan (all 13 actions to verify)

| # | Page | Action | Button/Trigger |
|---|------|--------|----------------|
| 1 | App Version Control | Save Android version | "Save Android Version" |
| 2 | App Version Control | Save iOS version | "Save iOS Version" |
| 3 | Sessions | Delete topic | Trash icon on topic row |
| 4 | Listeners | Activate/deactivate listener | Power icon |
| 5 | Listeners | Delete listener | Delete action |
| 6 | Listener detail | Update session status | "Cancel"/"Successful"/"Unsuccessful" |
| 7 | Settings | Change password | "Change Password" |
| 8 | Listeners | Send message | "Send Message" |
| 9 | Listeners | Update availability | "Update Availability" |
| 10 | Listener detail | Save schedule | "Save Changes" |
| 11 | Listener detail | Remove topic | Trash icon on topic |
| 12 | Users | Send notification | "Send" in notification modal |

For each: confirm dialog appears → "Cancel" dismisses → "Confirm" proceeds.