### PR TITLE
Add bulk notification page with audience targeting

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -34,7 +34,7 @@ const Notifications: React.FC = () => {
     validateToken();
   }, []);
 
-  const [target, setTarget] = useState<Target>('all');
+  const [target, setTarget] = useState<Target | ''>('');
   const [title, setTitle] = useState('');
   const [message, setMessage] = useState('');
   const [options, setOptions] = useState<NotificationOptions>({
@@ -146,13 +146,14 @@ const Notifications: React.FC = () => {
   };
 
   const isFormValid =
+    target !== '' &&
     title.trim() &&
     message.trim() &&
     (options.inApp || options.push || options.email) &&
     (target !== 'selected' || selectedUsers.length > 0);
 
   const handleSend = async () => {
-    if (!validateToken() || !isFormValid) return;
+    if (!validateToken() || !isFormValid || target === '') return;
 
     const targetLabel = target === 'selected'
       ? `${selectedUsers.length} selected user${selectedUsers.length > 1 ? 's' : ''}`
@@ -227,6 +228,9 @@ const Notifications: React.FC = () => {
             onChange={(e) => setTarget(e.target.value as Target)}
             className="w-full border border-gray-300 rounded-lg p-2.5 bg-white text-gray-900 focus:ring-red-500 focus:border-red-500"
           >
+            <option value="" disabled>
+              Select target audience
+            </option>
             {Object.entries(TARGET_LABELS).map(([value, label]) => (
               <option key={value} value={value}>
                 {label}

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -1,0 +1,376 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { Send, Search, X, Users, Bell } from 'lucide-react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Badge } from './ui/badge';
+import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api';
+import { API_URL } from '@/config/api';
+import { confirm } from '@/lib/confirm';
+
+type Target = 'all' | 'users' | 'listeners' | 'active_users' | 'inactive_users' | 'selected';
+
+interface SelectedUser {
+  id: string;
+  anonymousName: string;
+}
+
+interface NotificationOptions {
+  inApp: boolean;
+  push: boolean;
+  email: boolean;
+}
+
+const TARGET_LABELS: Record<Target, string> = {
+  all: 'All (Users + Listeners)',
+  users: 'All Users',
+  listeners: 'All Listeners',
+  active_users: 'Active Users (sessions in last 30 days)',
+  inactive_users: 'Inactive Users (no sessions in 30 days)',
+  selected: 'Selected Users',
+};
+
+const Notifications: React.FC = () => {
+  useEffect(() => {
+    validateToken();
+  }, []);
+
+  const [target, setTarget] = useState<Target>('all');
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [options, setOptions] = useState<NotificationOptions>({
+    inApp: true,
+    push: false,
+    email: false,
+  });
+  const [isSending, setIsSending] = useState(false);
+
+  const [alert, setAlert] = useState<{ type: 'success' | 'error' | null; message: string }>({
+    type: null,
+    message: '',
+  });
+
+  const showAlert = (type: 'success' | 'error', msg: string) => {
+    setAlert({ type, message: msg });
+    setTimeout(() => setAlert({ type: null, message: '' }), 5000);
+  };
+
+  // User picker state
+  const [selectedUsers, setSelectedUsers] = useState<SelectedUser[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState<SelectedUser[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch initial users when "selected" target is chosen
+  useEffect(() => {
+    if (target === 'selected') {
+      fetchUsers();
+    }
+  }, [target]);
+
+  const fetchUsers = async () => {
+    if (!validateToken()) return;
+    try {
+      setIsSearching(true);
+      const response = await fetch(`${API_URL}/users?skip=0&limit=20&sortBy=createdAt&sortOrder=desc`, {
+        headers: getAuthHeaders(),
+      });
+      if (response.status === 401) return handleUnauthorized(response);
+      if (!response.ok) return;
+      const data = await response.json();
+      setSearchResults(
+        (data.users || []).map((u: any) => ({
+          id: u.id,
+          anonymousName: u.anonymousName || 'Anonymous User',
+        }))
+      );
+    } catch {
+      // silently fail
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const searchUsers = async (term: string) => {
+    if (!validateToken()) return;
+    if (!term.trim()) {
+      fetchUsers();
+      return;
+    }
+    try {
+      setIsSearching(true);
+      const response = await fetch(
+        `${API_URL}/users/search/anonymous-name?anonymousName=${encodeURIComponent(term)}`,
+        { headers: getAuthHeaders() }
+      );
+      if (response.status === 401) return handleUnauthorized(response);
+      if (response.status === 404) {
+        setSearchResults([]);
+        return;
+      }
+      if (!response.ok) return;
+      const data = await response.json();
+      const userData = data.users
+        ? Array.isArray(data.users) ? data.users : [data.users]
+        : [];
+      setSearchResults(
+        userData.map((u: any) => ({
+          id: u.id,
+          anonymousName: u.anonymousName || 'Anonymous User',
+        }))
+      );
+    } catch {
+      // silently fail
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => searchUsers(value), 300);
+  };
+
+  const toggleUser = (user: SelectedUser) => {
+    setSelectedUsers((prev) =>
+      prev.some((u) => u.id === user.id)
+        ? prev.filter((u) => u.id !== user.id)
+        : [...prev, user]
+    );
+  };
+
+  const removeUser = (userId: string) => {
+    setSelectedUsers((prev) => prev.filter((u) => u.id !== userId));
+  };
+
+  const isFormValid =
+    title.trim() &&
+    message.trim() &&
+    (options.inApp || options.push || options.email) &&
+    (target !== 'selected' || selectedUsers.length > 0);
+
+  const handleSend = async () => {
+    if (!validateToken() || !isFormValid) return;
+
+    const targetLabel = target === 'selected'
+      ? `${selectedUsers.length} selected user${selectedUsers.length > 1 ? 's' : ''}`
+      : TARGET_LABELS[target].toLowerCase();
+
+    const confirmed = await confirm({
+      title: 'Send Bulk Notification',
+      description: `Send this notification to ${targetLabel}?`,
+      confirmText: 'Send',
+      variant: 'default',
+    });
+    if (!confirmed) return;
+
+    setIsSending(true);
+    try {
+      const body: any = { title, message, options, target };
+      if (target === 'selected') {
+        body.userIds = selectedUsers.map((u) => u.id);
+      }
+
+      const response = await fetch(`${API_URL}/notifications/send-bulk`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(body),
+      });
+
+      if (response.status === 401) return handleUnauthorized(response);
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.message || 'Failed to send notifications');
+      }
+
+      showAlert('success', 'Notifications sent successfully!');
+      setTitle('');
+      setMessage('');
+      setSelectedUsers([]);
+    } catch (err) {
+      showAlert('error', err instanceof Error ? err.message : 'Failed to send notifications');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="p-2 sm:p-4 md:p-6">
+      <div className="flex items-center gap-3 mb-6">
+        <Bell className="h-6 w-6 text-gray-700" />
+        <h2 className="text-xl sm:text-2xl font-bold text-gray-800">Send Notification</h2>
+      </div>
+
+      {alert.type && (
+        <div
+          className={`mb-6 p-4 rounded-md ${
+            alert.type === 'success'
+              ? 'bg-green-100 text-green-700 border border-green-400'
+              : 'bg-red-100 text-red-700 border border-red-400'
+          }`}
+        >
+          {alert.message}
+        </div>
+      )}
+
+      <div className="max-w-2xl space-y-6">
+        {/* Target audience */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Target Audience
+          </label>
+          <select
+            value={target}
+            onChange={(e) => setTarget(e.target.value as Target)}
+            className="w-full border border-gray-300 rounded-lg p-2.5 bg-white text-gray-900 focus:ring-red-500 focus:border-red-500"
+          >
+            {Object.entries(TARGET_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* User picker — only when target is "selected" */}
+        {target === 'selected' && (
+          <div className="border border-gray-200 rounded-lg p-4 space-y-3 bg-white">
+            <label className="block text-sm font-medium text-gray-700">
+              Select Users ({selectedUsers.length} selected)
+            </label>
+
+            {/* Selected users as badges */}
+            {selectedUsers.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {selectedUsers.map((user) => (
+                  <Badge
+                    key={user.id}
+                    variant="secondary"
+                    className="flex items-center gap-1 pr-1"
+                  >
+                    {user.anonymousName}
+                    <button
+                      onClick={() => removeUser(user.id)}
+                      className="ml-1 hover:bg-gray-300 rounded-full p-0.5"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            {/* Search input */}
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <Input
+                placeholder="Search users by name..."
+                value={searchTerm}
+                onChange={handleSearchChange}
+                className="pl-9 bg-white border-gray-300 text-gray-900"
+              />
+            </div>
+
+            {/* Results list */}
+            <div className="max-h-60 overflow-y-auto border border-gray-200 rounded-md divide-y divide-gray-100">
+              {isSearching ? (
+                <div className="p-4 text-center text-sm text-gray-500">Searching...</div>
+              ) : searchResults.length === 0 ? (
+                <div className="p-4 text-center text-sm text-gray-500">No users found</div>
+              ) : (
+                searchResults.map((user) => (
+                  <label
+                    key={user.id}
+                    className="flex items-center p-2.5 hover:bg-gray-50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedUsers.some((u) => u.id === user.id)}
+                      onChange={() => toggleUser(user)}
+                      className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+                    />
+                    <span className="ml-3 text-sm text-gray-900">{user.anonymousName}</span>
+                  </label>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Title */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Notification title"
+            className="bg-white border-gray-300 text-gray-900"
+          />
+        </div>
+
+        {/* Message */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Message</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            placeholder="Write your notification message..."
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:ring-red-500 focus:border-red-500"
+          />
+        </div>
+
+        {/* Notification options */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Delivery Channels
+          </label>
+          <div className="flex flex-col space-y-2">
+            <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
+              <input
+                type="checkbox"
+                checked={options.inApp}
+                onChange={(e) => setOptions((prev) => ({ ...prev, inApp: e.target.checked }))}
+                className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              />
+              <span className="text-sm font-medium text-gray-900">In-App Notification</span>
+            </label>
+            <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
+              <input
+                type="checkbox"
+                checked={options.push}
+                onChange={(e) => setOptions((prev) => ({ ...prev, push: e.target.checked }))}
+                className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              />
+              <span className="text-sm font-medium text-gray-900">Push Notification</span>
+            </label>
+            <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
+              <input
+                type="checkbox"
+                checked={options.email}
+                onChange={(e) => setOptions((prev) => ({ ...prev, email: e.target.checked }))}
+                className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              />
+              <span className="text-sm font-medium text-gray-900">Email Notification</span>
+            </label>
+          </div>
+        </div>
+
+        {/* Send button */}
+        <Button
+          onClick={handleSend}
+          disabled={isSending || !isFormValid}
+          className="w-full bg-red-600 hover:bg-red-700 text-white"
+        >
+          <Send className="h-4 w-4 mr-2" />
+          {isSending ? 'Sending...' : 'Send Notification'}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Notifications;

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -20,6 +20,8 @@ interface NotificationOptions {
   email: boolean;
 }
 
+const isTargetSelected = (t: Target | ''): t is Target => t !== '';
+
 const TARGET_LABELS: Record<Target, string> = {
   all: 'All (Users + Listeners)',
   users: 'All Users',
@@ -153,7 +155,7 @@ const Notifications: React.FC = () => {
     (target !== 'selected' || selectedUsers.length > 0);
 
   const handleSend = async () => {
-    if (!validateToken() || !isFormValid || target === '') return;
+    if (!validateToken() || !isFormValid || !isTargetSelected(target)) return;
 
     const targetLabel = target === 'selected'
       ? `${selectedUsers.length} selected user${selectedUsers.length > 1 ? 's' : ''}`

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -7,7 +7,11 @@ import { getAuthHeaders, handleUnauthorized, validateToken } from '../utils/api'
 import { API_URL } from '@/config/api';
 import { confirm } from '@/lib/confirm';
 
-type Target = 'all' | 'users' | 'listeners' | 'active_users' | 'inactive_users' | 'selected';
+// Listener targets ("all" and "listeners") are intentionally omitted:
+// the backend doesn't deliver to listeners yet — push/email lookups throw
+// and in-app rows are orphaned. Re-add once listener notifications are
+// supported end-to-end.
+type Target = 'users' | 'active_users' | 'inactive_users' | 'selected';
 
 interface SelectedUser {
   id: string;
@@ -23,9 +27,7 @@ interface NotificationChannelOptions {
 const isTargetSelected = (t: Target | ''): t is Target => t !== '';
 
 const TARGET_LABELS: Record<Target, string> = {
-  all: 'All (Users + Listeners)',
   users: 'All Users',
-  listeners: 'All Listeners',
   active_users: 'Active Users (sessions in last 30 days)',
   inactive_users: 'Inactive Users (no sessions in 30 days)',
   selected: 'Selected Users',

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -14,7 +14,7 @@ interface SelectedUser {
   anonymousName: string;
 }
 
-interface NotificationOptions {
+interface NotificationChannelOptions {
   inApp: boolean;
   push: boolean;
   email: boolean;
@@ -39,7 +39,7 @@ const Notifications: React.FC = () => {
   const [target, setTarget] = useState<Target | ''>('');
   const [title, setTitle] = useState('');
   const [message, setMessage] = useState('');
-  const [options, setOptions] = useState<NotificationOptions>({
+  const [channels, setChannels] = useState<NotificationChannelOptions>({
     inApp: true,
     push: false,
     email: false,
@@ -151,7 +151,7 @@ const Notifications: React.FC = () => {
     target !== '' &&
     title.trim() &&
     message.trim() &&
-    (options.inApp || options.push || options.email) &&
+    (channels.inApp || channels.push || channels.email) &&
     (target !== 'selected' || selectedUsers.length > 0);
 
   const handleSend = async () => {
@@ -171,7 +171,7 @@ const Notifications: React.FC = () => {
 
     setIsSending(true);
     try {
-      const body: any = { title, message, options, target };
+      const body: any = { title, message, channels, target };
       if (target === 'selected') {
         body.userIds = selectedUsers.map((u) => u.id);
       }
@@ -329,7 +329,7 @@ const Notifications: React.FC = () => {
           />
         </div>
 
-        {/* Notification options */}
+        {/* Delivery channels */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Delivery Channels
@@ -338,8 +338,8 @@ const Notifications: React.FC = () => {
             <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
               <input
                 type="checkbox"
-                checked={options.inApp}
-                onChange={(e) => setOptions((prev) => ({ ...prev, inApp: e.target.checked }))}
+                checked={channels.inApp}
+                onChange={(e) => setChannels((prev) => ({ ...prev, inApp: e.target.checked }))}
                 className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
               />
               <span className="text-sm font-medium text-gray-900">In-App Notification</span>
@@ -347,8 +347,8 @@ const Notifications: React.FC = () => {
             <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
               <input
                 type="checkbox"
-                checked={options.push}
-                onChange={(e) => setOptions((prev) => ({ ...prev, push: e.target.checked }))}
+                checked={channels.push}
+                onChange={(e) => setChannels((prev) => ({ ...prev, push: e.target.checked }))}
                 className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
               />
               <span className="text-sm font-medium text-gray-900">Push Notification</span>
@@ -356,8 +356,8 @@ const Notifications: React.FC = () => {
             <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
               <input
                 type="checkbox"
-                checked={options.email}
-                onChange={(e) => setOptions((prev) => ({ ...prev, email: e.target.checked }))}
+                checked={channels.email}
+                onChange={(e) => setChannels((prev) => ({ ...prev, email: e.target.checked }))}
                 className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
               />
               <span className="text-sm font-medium text-gray-900">Email Notification</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Home, Users, UserCheck, BarChart2, Settings, LogOut, Menu, X, Smartphone, LucideIcon } from 'lucide-react';
+import { Home, Users, UserCheck, BarChart2, Settings, LogOut, Menu, X, Smartphone, Bell, LucideIcon } from 'lucide-react';
 import { useRouter } from 'next/router';
 
 interface NavItemProps {
@@ -19,6 +19,7 @@ const Sidebar: React.FC = () => {
   const menuItems = [
     { icon: Home, text: 'Dashboard', path: '/' },
     { icon: Users, text: 'Users', path: '/users' },
+    { icon: Bell, text: 'Notifications', path: '/notifications' },
     { icon: UserCheck, text: 'Listeners', path: '/listeners' },
     { icon: LogOut, text: 'Sessions', path: '/sessions' },
     // { icon: BarChart2, text: 'Analytics', path: '/analytics' },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Home, Users, UserCheck, BarChart2, Settings, LogOut, Menu, X, Smartphone, Bell, LucideIcon } from 'lucide-react';
+import { Home, Users, UserCheck, BarChart2, Settings, LogOut, Menu, X, Smartphone, Bell, Video, LucideIcon } from 'lucide-react';
 import { useRouter } from 'next/router';
 
 interface NavItemProps {
@@ -21,7 +21,7 @@ const Sidebar: React.FC = () => {
     { icon: Users, text: 'Users', path: '/users' },
     { icon: Bell, text: 'Notifications', path: '/notifications' },
     { icon: UserCheck, text: 'Listeners', path: '/listeners' },
-    { icon: LogOut, text: 'Sessions', path: '/sessions' },
+    { icon: Video, text: 'Sessions', path: '/sessions' },
     // { icon: BarChart2, text: 'Analytics', path: '/analytics' },
     { icon: Smartphone, text: 'App Version', path: '/app-version' },
     { icon: Settings, text: 'Settings', path: '/settings' },

--- a/src/components/Users.tsx
+++ b/src/components/Users.tsx
@@ -56,7 +56,7 @@ interface PaginatedResponse {
   currentPage: number;
 }
 
-interface NotificationOptions {
+interface NotificationChannelOptions {
   inApp: boolean;
   push: boolean;
   email: boolean;
@@ -66,7 +66,7 @@ interface NotificationRequest {
   userId: string;
   title: string;
   message: string;
-  options: NotificationOptions;
+  channels: NotificationChannelOptions;
 }
 
 interface UserDetailsModalProps {
@@ -323,7 +323,7 @@ const Users: React.FC = () => {
   const [showNotificationModal, setShowNotificationModal] = useState(false);
   const [notificationTitle, setNotificationTitle] = useState('');
   const [notificationMessage, setNotificationMessage] = useState('');
-  const [notificationOptions, setNotificationOptions] = useState<NotificationOptions>({
+  const [notificationChannels, setNotificationChannels] = useState<NotificationChannelOptions>({
     inApp: true,
     push: false,
     email: false
@@ -465,7 +465,7 @@ const Users: React.FC = () => {
         userId,
         title: notificationTitle,
         message: notificationMessage,
-        options: notificationOptions
+        channels: notificationChannels
       };
       const response = await fetch(`${API_URL}/notifications/send`, {
         method: 'POST',
@@ -499,7 +499,7 @@ const Users: React.FC = () => {
   const resetNotificationForm = () => {
     setNotificationTitle('');
     setNotificationMessage('');
-    setNotificationOptions({
+    setNotificationChannels({
       inApp: true,
       push: false,
       email: false
@@ -953,8 +953,8 @@ const Users: React.FC = () => {
                       <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
                         <input
                           type="checkbox"
-                          checked={notificationOptions.inApp}
-                          onChange={(e) => setNotificationOptions(prev => ({
+                          checked={notificationChannels.inApp}
+                          onChange={(e) => setNotificationChannels(prev => ({
                             ...prev,
                             inApp: e.target.checked
                           }))}
@@ -965,8 +965,8 @@ const Users: React.FC = () => {
                       <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
                         <input
                           type="checkbox"
-                          checked={notificationOptions.push}
-                          onChange={(e) => setNotificationOptions(prev => ({
+                          checked={notificationChannels.push}
+                          onChange={(e) => setNotificationChannels(prev => ({
                             ...prev,
                             push: e.target.checked
                           }))}
@@ -977,8 +977,8 @@ const Users: React.FC = () => {
                       <label className="flex items-center space-x-3 p-2 rounded-md hover:bg-gray-50">
                         <input
                           type="checkbox"
-                          checked={notificationOptions.email}
-                          onChange={(e) => setNotificationOptions(prev => ({
+                          checked={notificationChannels.email}
+                          onChange={(e) => setNotificationChannels(prev => ({
                             ...prev,
                             email: e.target.checked
                           }))}

--- a/src/pages/notifications/index.tsx
+++ b/src/pages/notifications/index.tsx
@@ -1,0 +1,10 @@
+import Layout from '@/components/Layout';
+import Notifications from '@/components/Notifications';
+
+export default function NotificationsPage() {
+  return (
+    <Layout>
+      <Notifications />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- Add "Notifications" entry to sidebar (Bell icon, between Users and Listeners)
- Create new `/notifications` page with a bulk notification form
- Support 6 target audience types: All, All Users, All Listeners, Active Users, Inactive Users, Selected Users
- When "Selected Users" is chosen, show a searchable user picker with checkboxes
- Confirmation dialog before sending (uses the existing `confirm()` utility)

## Dependencies
Requires the backend PR readysocial/ready-back-end#67 to be merged first for the new target types to work. Existing targets (all/users/listeners) work with the current backend.

## Test plan
- [ ] Navigate to Notifications page via sidebar
- [ ] Select "All" target, fill title + message, send — verify confirmation dialog appears
- [ ] Select "Selected Users" — verify user picker appears with search
- [ ] Search for a user, check their checkbox — verify badge appears
- [ ] Remove a selected user via the X on their badge
- [ ] Try sending with empty title/message — verify button is disabled
- [ ] Try sending "Selected Users" with no users selected — verify button is disabled
- [ ] Select "Active Users" and send (requires backend PR merged)
- [ ] Select "Inactive Users" and send (requires backend PR merged)